### PR TITLE
feat(新建/编辑): 日期计算中，如果依赖的字段为空，则结果返回空

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -495,7 +495,7 @@ function TIMEDIF(startTime, endTime, unit) {
 
 function DATEDIFV2(startTime, endTime, unit) {
     try {
-        if (startTime == null || startTime == null || unit == null) {
+        if (startTime == null || endTime == null || unit == null) {
             return null;
         }
         const startDate = moment(startTime).startOf('day');


### PR DESCRIPTION
--bug=1046088 --user=田学军 【0053353
】【北京东方泰洋幕墙股份有限公司】【网页端】【任务明细】上配置了计划工期（整数字段），配置默认值=DATEDIFV2(计划开始日期，计划结束日期，"D") 当计划开始日期值存在，计划结束日期不存在时，计划工期竟然算出了数值。而且是把计划结束日期当成当前日期计算出的数值（预期是不填写的时候不默认当天，就是空；如果bug里的企业已经改了配置，可以自己找个企业配置下；都能复现） https://www.tapd.cn/23787791/s/1869145